### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, assigned]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-122992/DiscoveriesBattleshipGame/security/code-scanning/2](https://github.com/IGE-122992/DiscoveriesBattleshipGame/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is scoped to only what this job needs.  
For this workflow, the script creates a PR comment via Issues API, so `issues: write` is required; add `contents: read` as baseline read access. Place this at workflow root (applies to all jobs) or directly under `jobs.notify`. Since there is only one job shown, root-level is clean and preserves behavior.

**File to change:** `.github/workflows/pr-notify.yml`  
**Change:** Insert:

```yml
permissions:
  contents: read
  issues: write
```

between `on:` block and `jobs:` block (or before `jobs:`). No imports/dependencies needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
