### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-122992/DiscoveriesBattleshipGame/security/code-scanning/1](https://github.com/IGE-122992/DiscoveriesBattleshipGame/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/deploy-docker.yml` at the workflow root (recommended here since there is one job).  
Use least privilege required for current steps: `contents: read` is sufficient for `actions/checkout` and build steps. No additional GitHub write permissions are needed for Docker Hub publish because it uses repository secrets, not GitHub package publishing.

Concretely:
- Edit `.github/workflows/deploy-docker.yml`.
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it after the `on:` trigger section and before `jobs:` to apply to the whole workflow.

No imports, methods, or definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
